### PR TITLE
Fit to width & hide image while it's loading

### DIFF
--- a/src/ImageViewer.js
+++ b/src/ImageViewer.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
-import React, { useRef, useEffect } from 'react';
 import { propOr, pathOr } from 'ramda';
+import React, { useState, useRef } from 'react';
 
 /**
  * Get the scale for this image.
@@ -47,6 +47,15 @@ const getResponseLikePDF = imgRef => {
  */
 const ImageViewer = ({ file, originalSizes, onLoadSuccess }) => {
   const imgRef = useRef(null);
+  const [isLoading, setLoading] = useState(true);
+
+  const onLoad = () => {
+    // Execute the callback.
+    onLoadSuccess(getResponseLikePDF(imgRef));
+
+    // Set the loading state to false.
+    setLoading(false);
+  };
 
   const scaleImage =
     !originalSizes[0] || !getScale(file)
@@ -59,10 +68,11 @@ const ImageViewer = ({ file, originalSizes, onLoadSuccess }) => {
   return (
     <img
       ref={imgRef}
-      onLoad={() => onLoadSuccess(getResponseLikePDF(imgRef))}
+      onLoad={onLoad}
       src={file.url || `data:${file.mimeType};base64,${file.data}`}
       style={{
         ...scaleImage,
+        opacity: isLoading ? 0 : 1,
         transform: `rotate(${getRotation(file)}deg)`,
       }}
     />

--- a/src/styles.css
+++ b/src/styles.css
@@ -107,7 +107,11 @@
 }
 
 .preview-content .preview-file img {
-  transition: all 250ms;
+  transition-delay: 0ms, 0ms, 0ms, 250ms;
+  transition-duration: 250ms, 250ms, 250ms, 350ms;
+  transition-property: width, height, transform, opacity;
+
+  transform-origin: center center;
 }
 
 .preview-pdf-page {

--- a/src/utils/getFitToScreenScale.js
+++ b/src/utils/getFitToScreenScale.js
@@ -25,7 +25,7 @@ const getViewportHeight = viewportElem =>
  * @param  {Object} contentElem
  * @return {Number}
  */
-const getFitToScreenScale = (viewportElem, contentElem) => {
+export const getFitToScreenScale = (viewportElem, contentElem) => {
   // Get the viewport ratio.
   const viewportWidth = getViewportWidth(viewportElem);
   const viewportHeight = getViewportHeight(viewportElem);
@@ -61,4 +61,22 @@ const getFitToScreenScale = (viewportElem, contentElem) => {
   );
 };
 
-export default getFitToScreenScale;
+/**
+ * Get the `scale` attribute for the "fit to width" option.
+ *
+ * @param  {Object} viewportElem
+ * @param  {Object} contentElem
+ * @return {Number}
+ */
+export const getFitToWidthScale = (viewportElem, contentElem) => {
+  // Get the viewport ratio.
+  const viewportWidth = getViewportWidth(viewportElem);
+
+  // Get the content ratio.
+  const contentWidth = contentElem.width || contentElem.offsetWidth;
+
+  // Get the scaling ratio in `0.25` steps.
+  return Math.round((viewportWidth / contentWidth) * 4) / 4;
+};
+
+export default getFitToWidthScale;


### PR DESCRIPTION

- Do "fit to width" instead of "fit to screen"
- Closes https://github.com/vendorpay/react-file-previewer/issues/44 (hide the image while it's loading)