### PR TITLE
Update codeowners and authors

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 * @jrkt
 * @vijay94
+* @arm1n

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "repository": "git@github.com:vendorpay/react-file-previewer.git",
-  "author": "Jonathan Stevens<jonathanstevens89@gmail.com>Jonathan Stevens<jonathanstevens89@gmail.com>, Vijay Sundharapandiyan<vijaycenation14@gmail.com>",
+  "author": "Jonathan Stevens<jonathanstevens89@gmail.com>Jonathan Stevens<jonathanstevens89@gmail.com>, Vijay Sundharapandiyan<vijaycenation14@gmail.com>, Armin Pfurtscheller<armin.pfurtscheller@gmail.com>",
   "keywords": [
     "pdf viewer",
     "file viewer",


### PR DESCRIPTION
@vijay94 This commit contains now the correct Github user for the contributors. We may need to drop commit [dc33835](https://github.com/vendorpay/react-file-previewer/commit/dc33835fa0afcdbbc51b8201cf4207f134578929).